### PR TITLE
Fix clang-cl compatibility

### DIFF
--- a/libwsk/berkeley.cpp
+++ b/libwsk/berkeley.cpp
@@ -194,7 +194,7 @@ static NTSTATUS WSKAPI convert_addrinfo_to_addrinfoex(
             break;
         }
 
-        Result = (addrinfoexW*)ExAllocatePoolZero(PagedPool, sizeof addrinfoexW, WSK_POOL_TAG);
+        Result = (addrinfoexW*)ExAllocatePoolZero(PagedPool, sizeof(addrinfoexW), WSK_POOL_TAG);
         if (Result == nullptr)
         {
             Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -282,7 +282,7 @@ static NTSTATUS WSKAPI convert_addrinfoex_to_addrinfo(
             break;
         }
 
-        Result = (addrinfo*)ExAllocatePoolZero(PagedPool, sizeof addrinfo, WSK_POOL_TAG);
+        Result = (addrinfo*)ExAllocatePoolZero(PagedPool, sizeof(addrinfo), WSK_POOL_TAG);
         if (Result == nullptr)
         {
             Status = STATUS_INSUFFICIENT_RESOURCES;

--- a/libwsk/libwsk.cpp
+++ b/libwsk/libwsk.cpp
@@ -289,7 +289,11 @@ static NTSTATUS WSKCompletionRoutine(
             }
             __except (EXCEPTION_EXECUTE_HANDLER)
             {
+#ifdef __clang__
+                __asm__ volatile ("nop");
+#else
                 __nop();
+#endif
             }
         }
 
@@ -652,7 +656,7 @@ static NTSTATUS WSKAPI WSKControlSocketUnsafeDownlevel(
                 }
 
                 auto RemoteAddress = static_cast<PSOCKADDR>(InputBuffer);
-                if (RemoteAddress == nullptr || InputSize < sizeof SOCKADDR)
+                if (RemoteAddress == nullptr || InputSize < sizeof(SOCKADDR))
                 {
                     Status = STATUS_INVALID_PARAMETER;
                     break;
@@ -865,14 +869,14 @@ NTSTATUS WSKAPI WSKBindUnsafe(
         return Status;
     }
 
-    if (Socket == nullptr || LocalAddress == nullptr || (LocalAddressLength < sizeof SOCKADDR))
+    if (Socket == nullptr || LocalAddress == nullptr || (LocalAddressLength < sizeof(SOCKADDR)))
     {
         Status = STATUS_INVALID_PARAMETER;
         return Status;
     }
 
-    if ((LocalAddress->sa_family == AF_INET  && LocalAddressLength < sizeof SOCKADDR_IN) ||
-        (LocalAddress->sa_family == AF_INET6 && LocalAddressLength < sizeof SOCKADDR_IN6))
+    if ((LocalAddress->sa_family == AF_INET  && LocalAddressLength < sizeof(SOCKADDR_IN)) ||
+        (LocalAddress->sa_family == AF_INET6 && LocalAddressLength < sizeof(SOCKADDR_IN6)))
     {
         Status = STATUS_INVALID_PARAMETER;
         return Status;
@@ -922,8 +926,8 @@ NTSTATUS WSKAPI WSKAcceptUnsafe(
             break;
         }
 
-        if ((LocalAddress  && (LocalAddressLength  < sizeof SOCKADDR)) ||
-            (RemoteAddress && (RemoteAddressLength < sizeof SOCKADDR)))
+        if ((LocalAddress  && (LocalAddressLength  < sizeof(SOCKADDR))) ||
+            (RemoteAddress && (RemoteAddressLength < sizeof(SOCKADDR))))
         {
             Status = STATUS_INVALID_PARAMETER;
             break;
@@ -1124,14 +1128,14 @@ NTSTATUS WSKAPI WSKConnectUnsafe(
             break;
         }
 
-        if (Socket == nullptr || RemoteAddress == nullptr || (RemoteAddressLength < sizeof SOCKADDR))
+        if (Socket == nullptr || RemoteAddress == nullptr || (RemoteAddressLength < sizeof(SOCKADDR)))
         {
             Status = STATUS_INVALID_PARAMETER;
             break;
         }
 
-        if ((RemoteAddress->sa_family == AF_INET  && RemoteAddressLength < sizeof SOCKADDR_IN) ||
-            (RemoteAddress->sa_family == AF_INET6 && RemoteAddressLength < sizeof SOCKADDR_IN6))
+        if ((RemoteAddress->sa_family == AF_INET  && RemoteAddressLength < sizeof(SOCKADDR_IN)) ||
+            (RemoteAddress->sa_family == AF_INET6 && RemoteAddressLength < sizeof(SOCKADDR_IN6)))
         {
             Status = STATUS_INVALID_PARAMETER;
             break;
@@ -1465,14 +1469,14 @@ NTSTATUS WSKAPI WSKSendToUnsafe(
 
         if (RemoteAddress)
         {
-            if (RemoteAddressLength < sizeof SOCKADDR)
+            if (RemoteAddressLength < sizeof(SOCKADDR))
             {
                 Status = STATUS_INVALID_PARAMETER;
                 break;
             }
 
-            if ((RemoteAddress->sa_family == AF_INET  && RemoteAddressLength < sizeof SOCKADDR_IN) ||
-                (RemoteAddress->sa_family == AF_INET6 && RemoteAddressLength < sizeof SOCKADDR_IN6))
+            if ((RemoteAddress->sa_family == AF_INET  && RemoteAddressLength < sizeof(SOCKADDR_IN)) ||
+                (RemoteAddress->sa_family == AF_INET6 && RemoteAddressLength < sizeof(SOCKADDR_IN6)))
             {
                 Status = STATUS_INVALID_PARAMETER;
                 break;
@@ -1689,7 +1693,7 @@ NTSTATUS WSKAPI WSKReceiveFromUnsafe(
 
         if (RemoteAddress)
         {
-            if (RemoteAddressLength < sizeof SOCKADDR)
+            if (RemoteAddressLength < sizeof(SOCKADDR))
             {
                 Status = STATUS_INVALID_PARAMETER;
                 break;
@@ -2114,7 +2118,7 @@ NTSTATUS WSKAPI WSKAddressToString(
     {
         auto Address = reinterpret_cast<SOCKADDR_INET*>(SockAddress);
 
-        if (Address == nullptr || AddressLength < sizeof ADDRESS_FAMILY)
+        if (Address == nullptr || AddressLength < sizeof(ADDRESS_FAMILY))
         {
             break;
         }
@@ -2162,7 +2166,7 @@ NTSTATUS WSKAPI WSKStringToAddress(
     {
         auto Address = reinterpret_cast<SOCKADDR_INET*>(SockAddress);
 
-        if (Address == nullptr || AddressLength == nullptr || *AddressLength < sizeof ADDRESS_FAMILY)
+        if (Address == nullptr || AddressLength == nullptr || *AddressLength < sizeof(ADDRESS_FAMILY))
         {
             break;
         }
@@ -2498,7 +2502,7 @@ NTSTATUS WSKAPI WSKGetSocketOpt(
                 *static_cast<ULONG*>(OutputBuffer) = SocketObject.RecvTimeout;
             }
 
-            *OutputSize = sizeof ULONG;
+            *OutputSize = sizeof(ULONG);
             break;
         }
 

--- a/libwsk/socket.cpp
+++ b/libwsk/socket.cpp
@@ -59,7 +59,7 @@ VOID WSKAPI WSKSocketsAVLTableInitialize()
 #else
         POOL_NX_ALLOCATION,
 #endif
-        max(sizeof SOCKET_OBJECT + sizeof RTL_BALANCED_LINKS, 64), WSK_POOL_TAG, 0);
+        max(sizeof(SOCKET_OBJECT) + sizeof(RTL_BALANCED_LINKS), 64), WSK_POOL_TAG, 0);
 
     ExInitializeFastMutex(&WSKSocketsAVLTableMutex);
 


### PR DESCRIPTION
Hi,

Two small source fixes so libwsk builds cleanly under clang-cl, in addition to MSVC. 

changes:
`sizeof TypeName` -> `sizeof(TypeName)`
__nop() -> `#ifdef __clang__` fallback

Testing
- MSVC (cl 19.44): builds, no diff in disassembly of touched functions.
- clang-cl 19.1.7 against WDK 10.0.19041.0: builds and links a working driver.